### PR TITLE
Fix xnu build

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -1383,6 +1383,13 @@
 			</dict>
 			<key>version</key>
 			<string>3789.51.2</string>
+			<key>dependencies</key>
+			<dict>
+				<key>build</key>
+				<array>
+					<string>dtrace_ctftools</string>
+				</array>
+			</dict>
 		</dict>
 		<key>libkxld</key>
 		<dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -913,6 +913,13 @@
 			<string>libdispatch</string>
 			<key>target</key>
 			<string>libfirehose_kernel</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu</string>
+				</array>
+			</dict>
 			<key>patchfiles</key>
 			<array>
 				<string>libdispatch-703.50.37.p1.patch</string>
@@ -1391,6 +1398,11 @@
 				<array>
 					<string>AvailabilityVersions</string>
 					<string>dtrace_host</string>
+					<string>libfirehose_kernel</string>
+				</array>
+				<key>header</key>
+				<array>
+					<string>AvailabilityVersions</string>
 				</array>
 			</dict>
 		</dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -978,6 +978,7 @@
 			<key>patchfiles</key>
 			<array>
 				<string>libplatform-126.50.8.p1.patch</string>
+				<string>libplatform-126.50.8.xcode.p1.patch</string>
 			</array>
 			<key>version</key>
 			<string>126.50.8</string>
@@ -988,6 +989,15 @@
 			<string>libplatform</string>
 			<key>target</key>
 			<string>libplatform dyld</string>
+			<key>version</key>
+			<string>126.50.8</string>
+		</dict>
+		<key>libplatform_os_headers</key>
+		<dict>
+			<key>original</key>
+			<string>libplatform</string>
+			<key>target</key>
+			<string>os headers</string>
 			<key>version</key>
 			<string>126.50.8</string>
 		</dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -10,6 +10,7 @@
 	<key>patch_sites</key>
 	<array>
 		<string>http://67.205.155.153/Patches</string>
+		<string>https://github.com/Andromeda-OS/darwinbuild/raw/master/patches</string>
 	</array>
 
 	<key>build</key>
@@ -195,6 +196,10 @@
 		<dict>
 			<key>version</key>
 			<string>26.50.4</string>
+			<key>patchfiles</key>
+			<array>
+				<string>AvailabilityVersions-26.50.4.install-location.p1.patch</string>
+			</array>
 		</dict>
 		<key>BerkeleyDB</key>
 		<dict>
@@ -923,6 +928,7 @@
 			<key>patchfiles</key>
 			<array>
 				<string>libdispatch-703.50.37.p1.patch</string>
+				<string>libdispatch-703.50.37.libfirehose.patch</string>
 			</array>
 			<key>version</key>
 			<string>703.50.37</string>
@@ -1405,6 +1411,10 @@
 					<string>AvailabilityVersions</string>
 				</array>
 			</dict>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-3789.51.2.fix-path.patch</string>
+			</array>
 		</dict>
 		<key>libkxld</key>
 		<dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -925,7 +925,8 @@
 			<key>patchfiles</key>
 			<array>
 				<string>libdispatch-703.50.37.p1.patch</string>
-				<string>libdispatch-703.50.37.libfirehose.patch</string>
+				<string>libdispatch-703.50.37.libfirehose.p1.patch</string>
+				<string>libdispatch-703.50.37.libfirehose-install.p1.patch</string>
 			</array>
 			<key>version</key>
 			<string>703.50.37</string>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -735,12 +735,14 @@
 			<key>version</key>
 			<string>209.50.12</string>
 		</dict>
-		<key>dtrace_ctftools</key>
+		<key>dtrace_host</key>
 		<dict>
 			<key>original</key>
 			<string>dtrace</string>
 			<key>target</key>
 			<string>dtrace_host</string>
+			<key>version</key>
+			<string>209.50.12</string>
 		</dict>
 		<key>dyld</key>
 		<dict>
@@ -1387,7 +1389,8 @@
 			<dict>
 				<key>build</key>
 				<array>
-					<string>dtrace_ctftools</string>
+					<string>AvailabilityVersions</string>
+					<string>dtrace_host</string>
 				</array>
 			</dict>
 		</dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -196,10 +196,6 @@
 		<dict>
 			<key>version</key>
 			<string>26.50.4</string>
-			<key>patchfiles</key>
-			<array>
-				<string>AvailabilityVersions-26.50.4.install-location.p1.patch</string>
-			</array>
 		</dict>
 		<key>BerkeleyDB</key>
 		<dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -919,6 +919,7 @@
 				<key>header</key>
 				<array>
 					<string>xnu</string>
+					<string>libplatform_os_headers</string>
 				</array>
 			</dict>
 			<key>patchfiles</key>
@@ -1420,6 +1421,7 @@
 			<key>patchfiles</key>
 			<array>
 				<string>xnu-3789.51.2.fix-path.patch</string>
+				<string>xnu-3789.51.2.fix-codesign.p1.patch</string>
 			</array>
 		</dict>
 		<key>libkxld</key>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -735,6 +735,13 @@
 			<key>version</key>
 			<string>209.50.12</string>
 		</dict>
+		<key>dtrace_ctftools</key>
+		<dict>
+			<key>original</key>
+			<string>dtrace</string>
+			<key>target</key>
+			<string>dtrace_host</string>
+		</dict>
 		<key>dyld</key>
 		<dict>
 			<key>patchfiles</key>


### PR DESCRIPTION
With all of the patches in this PR applied, `xnu` builds successfully using `darwinbuild` in the chroot, without requiring any modifications to the host system. However, for this to work, you must invoke darwinbuild multiple times, in the following order:

1. `sudo darwinbuild -headers AvailabilityVersions`
2. `sudo darwinbuild -headers libplatform_os_headers`
3. `sudo darwinbuild -headers xnu`
4. `sudo darwinbuild dtrace_host`
5. `sudo darwinbuild libfirehose_kernel`
6. `sudo darwinbuild AvailabilityVersions`
7. `sudo darwinbuild xnu`

This PR references several patches currently located in [the master branch of my darwinbuild fork](https://github.com/Andromeda-OS/darwinbuild/tree/master/patches). If you want me to relocate them, just let me know.