### PR TITLE
Add booter projects

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -87,7 +87,7 @@
 		<key>booter</key>
 		<dict>
 			<key>version</key>
-			<string>1.0.0</string>
+			<string>2.0.0</string>
 			<key>target</key>
 			<string>boot2</string>
 			<key>environment</key>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -83,6 +83,13 @@
 			<key>version</key>
 			<string>14</string>
 		</dict>
+		<key>booter</key>
+		<dict>
+			<key>version</key>
+			<string>1.0.0</string>
+			<key>target</key>
+			<string>boot2</string>
+		</dict>
 		<key>bootstrap_cmds</key>
 		<dict>
 			<key>version</key>
@@ -137,6 +144,15 @@
 		<dict>
 			<key>version</key>
 			<string>1005</string>
+		</dict>
+		<key>startupfiletool</key>
+		<dict>
+			<key>version</key>
+			<string>1.0.0</string>
+			<key>original</key>
+			<string>booter</string>
+			<key>target</key>
+			<string>startupfiletool</string>
 		</dict>
 		<key>subversion</key>
 		<dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -90,6 +90,11 @@
 			<string>1.0.0</string>
 			<key>target</key>
 			<string>boot2</string>
+			<key>environment</key>
+			<dict>
+				<key>RC_ARCHS</key>
+				<string>i386</string>
+			</dict>
 		</dict>
 		<key>bootstrap_cmds</key>
 		<dict>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -154,7 +154,7 @@
 		<key>startupfiletool</key>
 		<dict>
 			<key>version</key>
-			<string>1.0.0</string>
+			<string>2.0.0</string>
 			<key>original</key>
 			<string>booter</string>
 			<key>target</key>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -5,6 +5,7 @@
 
 	<key>source_sites</key>
 	<array>
+		<string>https://github.com/Andromeda-OS/darwinbuild-archives/raw/master</string>
 		<string>https://opensource.apple.com/tarballs</string>
 	</array>
 	<key>patch_sites</key>


### PR DESCRIPTION
This PR adds projects for `booter` and `startupfiletool` (which is an alias of `booter`) to the list. These projects build the MBR-based boot loader I originally developed for use with [the Andromeda kernel](https://github.com/Andromeda-OS/Kernel). They should work with the kernel used by PureDarwin, although I have not tested it yet.