### PR TITLE
Edit to build using High Sierra SDK

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -57,7 +57,7 @@
 		<key>RC_TARGET_CONFIG</key>
 		<string>MacOSX</string>
 		<key>SDKROOT</key>
-		<string>macosx10.12</string>
+		<string>macosx10.13</string>
 
 	</dict>
 
@@ -1421,7 +1421,7 @@
 			<key>environment</key>
 			<dict>
 				<key>SDKROOT</key>
-				<string>macosx10.12</string>
+				<string>macosx10.13</string>
 				<key>RC_ARCHS</key>
 				<string>x86_64</string>
 				<key>KERNEL_CONFIGS</key>
@@ -1457,7 +1457,7 @@
 			<key>environment</key>
 			<dict>
 				<key>SDKROOT</key>
-				<string>macosx10.12</string>
+				<string>macosx10.13</string>
 				<key>RC_ARCHS</key>
 				<string>x86_64</string>
 				<key>KERNEL_CONFIGS</key>


### PR DESCRIPTION
If the `macosx10.12` SDK is requested but is not installed in the chroot, the build will fail. In addition, Xcode 9 does not come with that version of the SDK by default. This fixes the build on my machine running the High Sierra beta.