### PR TITLE
Add xnu_headers project

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -941,7 +941,7 @@
 			<dict>
 				<key>header</key>
 				<array>
-					<string>xnu</string>
+					<string>xnu_headers</string>
 					<string>libplatform_os_headers</string>
 				</array>
 			</dict>
@@ -1437,6 +1437,34 @@
 					<string>dtrace_host</string>
 					<string>libfirehose_kernel</string>
 				</array>
+				<key>header</key>
+				<array>
+					<string>AvailabilityVersions</string>
+				</array>
+			</dict>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-3789.51.2.fix-path.patch</string>
+				<string>xnu-3789.51.2.fix-codesign.p1.patch</string>
+			</array>
+		</dict>
+		<key>xnu_headers</key>
+		<dict>
+			<key>environment</key>
+			<dict>
+				<key>SDKROOT</key>
+				<string>macosx10.13</string>
+				<key>RC_ARCHS</key>
+				<string>x86_64</string>
+				<key>KERNEL_CONFIGS</key>
+				<string>RELEASE</string>
+			</dict>
+			<key>original</key>
+			<string>xnu</string>
+			<key>version</key>
+			<string>3789.51.2</string>
+			<key>dependencies</key>
+			<dict>
 				<key>header</key>
 				<array>
 					<string>AvailabilityVersions</string>

--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -1469,6 +1469,10 @@
 				<array>
 					<string>AvailabilityVersions</string>
 				</array>
+				<key>build</key>
+				<array>
+					<string>dtrace_host</string>
+				</array>
 			</dict>
 			<key>patchfiles</key>
 			<array>


### PR DESCRIPTION
This project, an alias of `xnu`, exists to break a circular dependency between the `xnu` and `libfirehose_kernel` projects. I found this issue the hard way, while trying to run `darwinbuild -headers xnu` on a build-root without any prebuilt dependencies from previous runs.