### PR TITLE
Add additional patch to XNU build

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -1453,6 +1453,7 @@
 			<array>
 				<string>xnu-3789.51.2.fix-path.patch</string>
 				<string>xnu-3789.51.2.fix-codesign.p1.patch</string>
+				<string>xnu-3789.51.2.xcode9-warnings.p1.patch</string>
 			</array>
 		</dict>
 		<key>xnu_headers</key>


### PR DESCRIPTION
This PR enables the patch committed in csekel/darwinbuild#12. It is needed to successfully compile `xnu` on a machine running Xcode 9.