### PR TITLE
Download from GitHub Releases where appropriate

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -5,7 +5,6 @@
 
 	<key>source_sites</key>
 	<array>
-		<string>https://github.com/Andromeda-OS/darwinbuild-archives/raw/master</string>
 		<string>https://opensource.apple.com/tarballs</string>
 	</array>
 	<key>patch_sites</key>
@@ -91,6 +90,8 @@
 			<string>2.0.0</string>
 			<key>target</key>
 			<string>boot2</string>
+			<key>github</key>
+			<string>Andromeda-OS/booter</string>
 			<key>environment</key>
 			<dict>
 				<key>RC_ARCHS</key>


### PR DESCRIPTION
This is a follow-up PR for csekel/darwinbuild#14. See there for the rationale behind this change.