### PR TITLE
Add AppleI386GenericPlatform project

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -176,6 +176,25 @@
 			<key>version</key>
 			<string>21</string>
 		</dict>
+		<key>AppleI386GenericPlatform</key>
+		<dict>
+			<key>version</key>
+			<string>10.0</string>
+			<key>github</key>
+			<string>Andromeda-OS/AppleI386GenericPlatform</string>
+			<key>environment</key>
+			<dict>
+				<key>RC_ARCHS</key>
+				<string>x86_64</string>
+			</dict>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+				</array>
+			</dict>
+		</dict>
 		<key>AppleRAID</key>
 		<dict>
 			<key>patchfiles</key>


### PR DESCRIPTION
Does what it says in the title. Note that csekel/darwinbuild#14 will need to be merged before these changes will build successfully.