### PR TITLE
Bump version of AppleI386GenericPlatform

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -184,7 +184,7 @@
 		<key>AppleI386GenericPlatform</key>
 		<dict>
 			<key>version</key>
-			<string>10.0</string>
+			<string>11.0</string>
 			<key>github</key>
 			<string>Andromeda-OS/AppleI386GenericPlatform</string>
 			<key>environment</key>


### PR DESCRIPTION
The new version includes fixes to work correctly with the current version of `darwinbuild`.