### PR TITLE
Update booter to booter-3.1.1

### DIFF
--- a/SUFuji16E195.plist
+++ b/SUFuji16E195.plist
@@ -91,7 +91,7 @@
 		<key>booter</key>
 		<dict>
 			<key>version</key>
-			<string>3</string>
+			<string>3.1.1</string>
 			<key>target</key>
 			<string>boot2</string>
 			<key>github</key>


### PR DESCRIPTION
This version of the `booter` project contains compilation fixes for Xcode 9, as well as a functionality update to boot `xnu-3789.51.2` correctly under QEMU.