### PR TITLE
High Sierra migration

### DIFF
--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -20,8 +20,8 @@
 	<string>Darwin 17</string>
 	<key>macosx</key>
 	<string>macOS 10.13</string>
-	<key>environment</key>
 
+	<key>environment</key>
 	<dict>
 		<key>INSTALLED_PRODUCT_ASIDES</key>
 		<string>YES</string>
@@ -55,7 +55,6 @@
 		<string>MacOSX</string>
 		<key>SDKROOT</key>
 		<string>macosx10.13</string>
-
 	</dict>
 
 	<key>groups</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -11,7 +11,7 @@
 	<array>
 		<string>http://67.205.155.153/Patches</string>
 		<string>https://github.com/csekel/darwinbuild/raw/master/patches</string>
-		<string>https://github.com/Andromeda-OS/darwinbuild/raw/master/patches</string>
+		<string>https://github.com/Andromeda-OS/PureDarwin-System-Plist/raw/master/patches</string>
 	</array>
 
 	<key>build</key>
@@ -556,6 +556,19 @@
 		<dict>
 			<key>version</key>
 			<string>262</string>
+		</dict>
+		<key>dtrace_host</key>
+		<dict>
+			<key>version</key>
+			<string>262</string>
+			<key>original</key>
+			<string>dtrace</string>
+			<key>target</key>
+			<string>dtrace_host</string>
+			<key>patchfiles</key>
+			<array>
+				<string>dtrace-262.install-paths.p1.patch</string>
+			</array>
 		</dict>
 		<key>dyld</key>
 		<dict>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -1114,6 +1114,7 @@
 				<string>xnu-4570.1.46.availability-path.p1.patch</string>
 				<string>xnu-4570.1.46.dtrace-host.p1.patch</string>
 				<string>xnu-4570.1.46.fix-codesign.p1.patch</string>
+				<string>xnu-4570.1.46.system-framework.p1.patch</string>
 			</array>
 		</dict>
 		<key>zip</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -739,6 +739,22 @@
 		<dict>
 			<key>version</key>
 			<string>161</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+				</array>
+			</dict>
+		</dict>
+		<key>libplatform_headers</key>
+		<dict>
+			<key>version</key>
+			<string>161</string>
+			<key>original</key>
+			<string>libplatform</string>
+			<key>target</key>
+			<string>headers</string>
 		</dict>
 		<key>libpthread</key>
 		<dict>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -716,6 +716,28 @@
 			<key>version</key>
 			<string>18.1</string>
 		</dict>
+		<key>libfirehose_kernel</key>
+		<dict>
+			<key>version</key>
+			<string>913.1.6</string>
+			<key>original</key>
+			<string>libdispatch</string>
+			<key>target</key>
+			<string>libfirehose_kernel</string>
+			<key>patchfiles</key>
+			<array>
+				<string>libdispatch-913.1.6.libfirehose-kernel.p1.patch</string>
+			</array>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+					<string>libplatform_headers</string>
+					<string>CarbonHeaders</string>
+				</array>
+			</dict>
+		</dict>
 		<key>libfs</key>
 		<dict>
 			<key>version</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -513,6 +513,20 @@
 			<key>version</key>
 			<string>155</string>
 		</dict>
+		<key>corecrypto</key>
+		<dict>
+			<key>version</key>
+			<string>1150.3</string>
+			<key>github</key>
+			<string>Andromeda-OS/corecrypto</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+				</array>
+			</dict>
+		</dict>
 		<key>cron</key>
 		<dict>
 			<key>version</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -1110,8 +1110,38 @@
 		</dict>
 		<key>xnu</key>
 		<dict>
+			<key>environment</key>
+			<dict>
+				<key>RC_ARCHS</key>
+				<string>x86_64</string>
+				<key>KERNEL_CONFIGS</key>
+				<string>RELEASE</string>
+			</dict>
 			<key>version</key>
 			<string>4570.1.46</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>AvailabilityVersions</string>
+				</array>
+				<key>build</key>
+				<array>
+					<string>AvailabilityVersions</string>
+					<string>dtrace_host</string>
+					<string>libfirehose_kernel</string>
+				</array>
+			</dict>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-4570.1.46.availability-path.p1.patch</string>
+				<string>xnu-4570.1.46.dtrace-host.p1.patch</string>
+				<string>xnu-4570.1.46.fix-codesign.p1.patch</string>
+				<string>xnu-4570.1.46.system-framework.p1.patch</string>
+				<string>xnu-4570.1.46.copyright-check.p1.patch</string>
+				<string>xnu-4570.1.46.firehose-buildroot.p1.patch</string>
+				<string>xnu-4570.1.46.xcode9-warnings.p1.patch</string>
+			</array>
 		</dict>
 		<key>xnu_headers</key>
 		<dict>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -108,6 +108,20 @@
 			<key>github</key>
 			<string>Andromeda-OS/CarbonHeaders</string>
 		</dict>
+		<key>cdrtools</key>
+		<dict>
+			<key>version</key>
+			<string>3.02.0.0.1</string>
+			<key>github</key>
+			<string>Andromeda-OS/cdrtools</string>
+			<key>dependencies</key>
+			<dict>
+				<key>build</key>
+				<array>
+					<string>schilymake</string>
+				</array>
+			</dict>
+		</dict>
 		<key>CF</key>
 		<dict>
 			<key>version</key>
@@ -1010,6 +1024,13 @@
 		<dict>
 			<key>version</key>
 			<string>131</string>
+		</dict>
+		<key>schilymake</key>
+		<dict>
+			<key>version</key>
+			<string>1.2.5</string>
+			<key>github</key>
+			<string>Andromeda-OS/schilymake</string>
 		</dict>
 		<key>screen</key>
 		<dict>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -478,6 +478,20 @@
 			<key>version</key>
 			<string>7604.1.38.1.6</string>
 		</dict>
+		<key>booter</key>
+		<dict>
+			<key>environment</key>
+			<dict>
+				<key>RC_ARCHS</key>
+				<string>i386</string>
+			</dict>
+			<key>version</key>
+			<string>3.1.1</string>
+			<key>target</key>
+			<string>boot2</string>
+			<key>github</key>
+			<string>Andromeda-OS/booter</string>
+		</dict>
 		<key>bootp</key>
 		<dict>
 			<key>version</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -101,6 +101,13 @@
 			<key>version</key>
 			<string>128</string>
 		</dict>
+		<key>CarbonHeaders</key>
+		<dict>
+			<key>version</key>
+			<string>100</string>
+			<key>github</key>
+			<string>Andromeda-OS/CarbonHeaders</string>
+		</dict>
 		<key>CF</key>
 		<dict>
 			<key>version</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -743,6 +743,7 @@
 				<key>header</key>
 				<array>
 					<string>xnu_headers</string>
+					<string>libplatform_headers</string>
 				</array>
 			</dict>
 		</dict>
@@ -752,8 +753,6 @@
 			<string>161</string>
 			<key>original</key>
 			<string>libplatform</string>
-			<key>target</key>
-			<string>headers</string>
 		</dict>
 		<key>libpthread</key>
 		<dict>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -2,17 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-
 	<key>source_sites</key>
 	<array>
 		<string>https://opensource.apple.com/tarballs</string>
 	</array>
+
 	<key>patch_sites</key>
 	<array>
 		<string>http://67.205.155.153/Patches</string>
 		<string>https://github.com/csekel/darwinbuild/raw/master/patches</string>
 		<string>https://github.com/Andromeda-OS/darwinbuild/raw/master/patches</string>
 	</array>
+
 	<key>build</key>
 	<string>Lobo17A365</string>
 	<key>darwin</key>
@@ -20,6 +21,7 @@
 	<key>macosx</key>
 	<string>macOS 10.13</string>
 	<key>environment</key>
+
 	<dict>
 		<key>INSTALLED_PRODUCT_ASIDES</key>
 		<string>YES</string>
@@ -67,6 +69,7 @@
 			<string>xnu AppleI386GenericPlatform corecrypto booter</string>
 		</array>
 	</dict>
+
 	<key>projects</key>
 	<dict>
 		<key>AppleFileSystemDriver</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -76,6 +76,25 @@
 			<key>version</key>
 			<string>23</string>
 		</dict>
+		<key>AppleI386GenericPlatform</key>
+		<dict>
+			<key>version</key>
+			<string>11.0</string>
+			<key>github</key>
+			<string>Andromeda-OS/AppleI386GenericPlatform</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+				</array>
+			</dict>
+			<key>environment</key>
+			<dict>
+				<key>RC_ARCHS</key>
+				<string>x86_64</string>
+			</dict>
+		</dict>
 		<key>AppleRAID</key>
 		<dict>
 			<key>version</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -108,20 +108,6 @@
 			<key>github</key>
 			<string>Andromeda-OS/CarbonHeaders</string>
 		</dict>
-		<key>cdrtools</key>
-		<dict>
-			<key>version</key>
-			<string>3.02.0.0.1</string>
-			<key>github</key>
-			<string>Andromeda-OS/cdrtools</string>
-			<key>dependencies</key>
-			<dict>
-				<key>build</key>
-				<array>
-					<string>schilymake</string>
-				</array>
-			</dict>
-		</dict>
 		<key>CF</key>
 		<dict>
 			<key>version</key>
@@ -525,6 +511,20 @@
 		<dict>
 			<key>version</key>
 			<string>263</string>
+		</dict>
+		<key>cdrtools</key>
+		<dict>
+			<key>version</key>
+			<string>3.02.0.0.1</string>
+			<key>github</key>
+			<string>Andromeda-OS/cdrtools</string>
+			<key>dependencies</key>
+			<dict>
+				<key>build</key>
+				<array>
+					<string>schilymake</string>
+				</array>
+			</dict>
 		</dict>
 		<key>configd</key>
 		<dict>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -1070,6 +1070,37 @@
 			<key>version</key>
 			<string>4570.1.46</string>
 		</dict>
+		<key>xnu_headers</key>
+		<dict>
+			<key>environment</key>
+			<dict>
+				<key>RC_ARCHS</key>
+				<string>x86_64</string>
+				<key>KERNEL_CONFIGS</key>
+				<string>RELEASE</string>
+			</dict>
+			<key>original</key>
+			<string>xnu</string>
+			<key>version</key>
+			<string>4570.1.46</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>AvailabilityVersions</string>
+				</array>
+				<key>build</key>
+				<array>
+					<string>dtrace_host</string>
+				</array>
+			</dict>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-4570.1.46.availability-path.p1.patch</string>
+				<string>xnu-4570.1.46.dtrace-host.p1.patch</string>
+				<string>xnu-4570.1.46.fix-codesign.p1.patch</string>
+			</array>
+		</dict>
 		<key>zip</key>
 		<dict>
 			<key>version</key>

--- a/patches/dtrace-262.install-paths.p1.patch
+++ b/patches/dtrace-262.install-paths.p1.patch
@@ -1,0 +1,52 @@
+diff --git a/dtrace.xcodeproj/project.pbxproj b/dtrace.xcodeproj/project.pbxproj
+index f237b76..8e9b757 100644
+--- a/dtrace.xcodeproj/project.pbxproj
++++ b/dtrace.xcodeproj/project.pbxproj
+@@ -13127,7 +13127,6 @@
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+ 				GCC_MODEL_TUNING = G5;
+ 				GCC_OPTIMIZATION_LEVEL = 0;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -13157,7 +13156,6 @@
+ 				);
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+ 				GCC_MODEL_TUNING = G5;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -13189,7 +13187,6 @@
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+ 				GCC_MODEL_TUNING = G5;
+ 				GCC_OPTIMIZATION_LEVEL = 0;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -13218,7 +13215,6 @@
+ 				);
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+ 				GCC_MODEL_TUNING = G5;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -13284,7 +13280,6 @@
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+ 				GCC_MODEL_TUNING = G5;
+ 				GCC_OPTIMIZATION_LEVEL = 0;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -13314,7 +13309,6 @@
+ 				);
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+ 				GCC_MODEL_TUNING = G5;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",

--- a/patches/libdispatch-913.1.6.libfirehose-kernel.p1.patch
+++ b/patches/libdispatch-913.1.6.libfirehose-kernel.p1.patch
@@ -1,0 +1,13 @@
+diff --git a/xcodeconfig/libfirehose_kernel.xcconfig b/xcodeconfig/libfirehose_kernel.xcconfig
+index c572f80..1c567bd 100644
+--- a/xcodeconfig/libfirehose_kernel.xcconfig
++++ b/xcodeconfig/libfirehose_kernel.xcconfig
+@@ -27,7 +27,7 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) KERNEL=1 DISPATCH_USE_DTRACE=0
+ OTHER_CFLAGS = -mkernel -nostdinc -Wno-packed
+ // LLVM_LTO = YES
+ PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/kernel/os
+-HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(SDKROOT)/System/Library/Frameworks/Kernel.framework/Headers $(SDKROOT)/usr/local/include/os $(SDKROOT)/usr/local/include/firehose
++HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(RC_BuildRoot)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(RC_BuildRoot)/System/Library/Frameworks/Kernel.framework/Headers $(RC_BuildRoot)/usr/local/include/os $(RC_BuildRoot)/usr/local/include/firehose
+ 
+ COPY_HEADERS_RUN_UNIFDEF = YES
+ COPY_HEADERS_UNIFDEF_FLAGS = -DKERNEL=1 -DOS_FIREHOSE_SPI=1 -DOS_VOUCHER_ACTIVITY_SPI_TYPES=1 -UOS_VOUCHER_ACTIVITY_SPI

--- a/patches/xnu-4570.1.46.availability-path.p1.patch
+++ b/patches/xnu-4570.1.46.availability-path.p1.patch
@@ -1,0 +1,33 @@
+diff --git a/bsd/sys/make_symbol_aliasing.sh b/bsd/sys/make_symbol_aliasing.sh
+index ef47e37..a1e694a 100755
+--- a/bsd/sys/make_symbol_aliasing.sh
++++ b/bsd/sys/make_symbol_aliasing.sh
+@@ -34,8 +34,8 @@ fi
+ SDKROOT="$1"
+ OUTPUT="$2"
+
+-if [ ! -x "${SDKROOT}/usr/local/libexec/availability.pl" ] ; then
+-    echo "Unable to locate ${SDKROOT}/usr/local/libexec/availability.pl (or not executable)" >&2
++if [ ! -x "${RC_BuildRoot}/usr/local/libexec/availability.pl" ] ; then
++    echo "Unable to locate ${RC_BuildRoot}/usr/local/libexec/availability.pl (or not executable)" >&2
+     exit 1
+ fi
+
+@@ -74,7 +74,7 @@ cat <<EOF
+
+ EOF
+
+-for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
++for ver in $(${RC_BuildRoot}/usr/local/libexec/availability.pl --ios) ; do
+     ver_major=${ver%.*}
+     ver_minor=${ver#*.}
+     value=$(printf "%d%02d00" ${ver_major} ${ver_minor})
+@@ -87,7 +87,7 @@ for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
+     echo ""
+ done
+
+-for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --macosx) ; do
++for ver in $(${RC_BuildRoot}/usr/local/libexec/availability.pl --macosx) ; do
+     set -- $(echo "$ver" | tr '.' ' ')
+     ver_major=$1
+     ver_minor=$2

--- a/patches/xnu-4570.1.46.copyright-check.p1.patch
+++ b/patches/xnu-4570.1.46.copyright-check.p1.patch
@@ -1,0 +1,22 @@
+diff --git a/libkern/kxld/kxld_copyright.c b/libkern/kxld/kxld_copyright.c
+index e1f13c2..8664226 100644
+--- a/libkern/kxld/kxld_copyright.c
++++ b/libkern/kxld/kxld_copyright.c
+@@ -49,6 +49,7 @@
+ 
+ #define kCopyrightToken "Copyright © "
+ #define kRightsToken " Apple Inc. All rights reserved."
++#define kRightsTokenPD " PureDarwin Project. All rights reserved."
+ 
+ /******************************************************************************
+ * Globals
+@@ -252,6 +253,9 @@ kxld_validate_copyright_string(const char *str)
+ 
+     copyright = kxld_strstr(str, kCopyrightToken);
+     rights = kxld_strstr(str, kRightsToken);
++    if (!rights) {
++        rights = kxld_strstr(str, kRightsTokenPD);
++    }
+ 
+     if (!copyright || !rights || copyright > rights) goto finish;
+ 

--- a/patches/xnu-4570.1.46.dtrace-host.p1.patch
+++ b/patches/xnu-4570.1.46.dtrace-host.p1.patch
@@ -1,0 +1,17 @@
+diff --git a/makedefs/MakeInc.cmd b/makedefs/MakeInc.cmd
+index a70a2d8..6e668a5 100644
+--- a/makedefs/MakeInc.cmd
++++ b/makedefs/MakeInc.cmd
+@@ -103,10 +103,10 @@ ifeq ($(DSYMUTIL),)
+ 	export DSYMUTIL := $(shell $(XCRUN) -sdk $(SDKROOT) -find dsymutil)
+ endif
+ ifeq ($(CTFCONVERT),)
+-	export CTFCONVERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfconvert)
++	export CTFCONVERT := $(RC_BuildRoot)/usr/local/bin/ctfconvert
+ endif
+ ifeq ($(CTFMERGE),)
+-	export CTFMERGE :=  $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfmerge)
++	export CTFMERGE :=  $(RC_BuildRoot)/usr/local/bin/ctfmerge
+ endif
+ ifeq ($(CTFINSERT),)
+ 	export CTFINSERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctf_insert)

--- a/patches/xnu-4570.1.46.firehose-buildroot.p1.patch
+++ b/patches/xnu-4570.1.46.firehose-buildroot.p1.patch
@@ -1,0 +1,22 @@
+diff --git a/makedefs/MakeInc.def b/makedefs/MakeInc.def
+index 4eca357..653af06 100644
+--- a/makedefs/MakeInc.def
++++ b/makedefs/MakeInc.def
+@@ -356,7 +356,7 @@ LDFLAGS_KERNEL_GEN = \
+ 	-Wl,-function_starts \
+ 	-Wl,-headerpad,152
+ 
+-LDFLAGS_KERNEL_SDK	= -L$(SDKROOT)/usr/local/lib/kernel -lfirehose_kernel
++LDFLAGS_KERNEL_SDK	= -L$(RC_BuildRoot)/usr/local/lib/kernel -lfirehose_kernel
+ 
+ LDFLAGS_KERNEL_RELEASE	=
+ LDFLAGS_KERNEL_DEVELOPMENT     =
+@@ -464,7 +464,7 @@ INCFLAGS_IMPORT	= $(patsubst %, -I$(OBJROOT)/EXPORT_HDRS/%, $(COMPONENT_IMPORT_L
+ INCFLAGS_EXTERN	= -I$(SRCROOT)/EXTERNAL_HEADERS
+ INCFLAGS_GEN	= -I$(SRCROOT)/$(COMPONENT) -I$(OBJROOT)/EXPORT_HDRS/$(COMPONENT)
+ INCFLAGS_LOCAL	= -I.
+-INCFLAGS_SDK	= -I$(SDKROOT)/usr/local/include/kernel
++INCFLAGS_SDK	= -I$(RC_BuildRoot)/usr/local/include/kernel
+ 
+ INCFLAGS	= $(INCFLAGS_LOCAL) $(INCFLAGS_GEN) $(INCFLAGS_IMPORT) $(INCFLAGS_EXTERN) $(INCFLAGS_MAKEFILE) $(INCFLAGS_SDK)
+ 

--- a/patches/xnu-4570.1.46.fix-codesign.p1.patch
+++ b/patches/xnu-4570.1.46.fix-codesign.p1.patch
@@ -1,0 +1,91 @@
+diff --git a/SETUP/config/Makefile b/SETUP/config/Makefile
+index 56032b4..1e73452 100644
+--- a/SETUP/config/Makefile
++++ b/SETUP/config/Makefile
+@@ -20,7 +20,7 @@ config: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/decomment/Makefile b/SETUP/decomment/Makefile
+index 7018eb1..877ca15 100644
+--- a/SETUP/decomment/Makefile
++++ b/SETUP/decomment/Makefile
+@@ -18,7 +18,7 @@ decomment: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/installfile/Makefile b/SETUP/installfile/Makefile
+index eb1f3af..a74b483 100644
+--- a/SETUP/installfile/Makefile
++++ b/SETUP/installfile/Makefile
+@@ -18,7 +18,7 @@ installfile: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/json_compilation_db/Makefile b/SETUP/json_compilation_db/Makefile
+index 518644c..bf453c3 100644
+--- a/SETUP/json_compilation_db/Makefile
++++ b/SETUP/json_compilation_db/Makefile
+@@ -18,7 +18,7 @@ json_compilation_db: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/kextsymboltool/Makefile b/SETUP/kextsymboltool/Makefile
+index af6cdca..e38782f 100644
+--- a/SETUP/kextsymboltool/Makefile
++++ b/SETUP/kextsymboltool/Makefile
+@@ -18,7 +18,7 @@ kextsymboltool: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/replacecontents/Makefile b/SETUP/replacecontents/Makefile
+index e1e8484..44b81b9 100644
+--- a/SETUP/replacecontents/Makefile
++++ b/SETUP/replacecontents/Makefile
+@@ -18,7 +18,7 @@ replacecontents: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/setsegname/Makefile b/SETUP/setsegname/Makefile
+index 7e9224e..c2ed335 100644
+--- a/SETUP/setsegname/Makefile
++++ b/SETUP/setsegname/Makefile
+@@ -18,7 +18,7 @@ setsegname: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"

--- a/patches/xnu-4570.1.46.system-framework.p1.patch
+++ b/patches/xnu-4570.1.46.system-framework.p1.patch
@@ -1,0 +1,20 @@
+diff --git a/makedefs/MakeInc.kernel b/makedefs/MakeInc.kernel
+index 0885b3f..49c2f1f 100644
+--- a/makedefs/MakeInc.kernel
++++ b/makedefs/MakeInc.kernel
+@@ -281,6 +281,15 @@ do_installhdrs_mi:: $(DSTROOT)/$(KRESDIR)/Info.plist
+ 	$(_v)$(RM) $(DSTROOT)/$(KINCFRAME)/Resources
+ 	$(_v)$(LN) Versions/Current/Resources			\
+ 		   $(DSTROOT)/$(KINCFRAME)/Resources
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/Versions/Current
++	$(_v)$(LN) $(SINCVERS) \
++		   $(DSTROOT)/$(SINCFRAME)/Versions/Current
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/PrivateHeaders
++	$(_v)$(LN) Versions/Current/PrivateHeaders		\
++		   $(DSTROOT)/$(SINCFRAME)/PrivateHeaders
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/Resources
++	$(_v)$(LN) Versions/Current/Resources			\
++		   $(DSTROOT)/$(SINCFRAME)/Resources
+ 
+ $(DSTROOT)/$(KRESDIR)/Info.plist: $(SOURCE)/EXTERNAL_HEADERS/Info.plist
+ 	$(_v)$(MKDIR) $(DSTROOT)/$(KRESDIR)

--- a/patches/xnu-4570.1.46.xcode9-warnings.p1.patch
+++ b/patches/xnu-4570.1.46.xcode9-warnings.p1.patch
@@ -1,0 +1,33 @@
+diff --git a/makedefs/MakeInc.def b/makedefs/MakeInc.def
+index 653af06..f75aefe 100644
+--- a/makedefs/MakeInc.def
++++ b/makedefs/MakeInc.def
+@@ -143,6 +143,7 @@ WARNFLAGS_STD := \
+ 	-Wno-partial-availability \
+ 	-Wno-pedantic \
+ 	-Wno-shift-sign-overflow \
++	-Wno-strict-prototypes \
+ 	-Wno-switch-enum \
+ 	-Wno-undef \
+ 	-Wno-unused-macros \
+@@ -157,7 +158,11 @@ CWARNFLAGS_STD = \
+ 	-Wmissing-prototypes \
+ 	-Wshadow \
+ 	-Winline \
+-	-Wnested-externs
++	-Wnested-externs \
++	-Wno-cast-align \
++	-Wno-format-invalid-specifier \
++	-Wno-ignored-attributes \
++	-Wno-strict-prototypes
+ 
+ # Can be overridden in Makefile.template or Makefile.$arch
+ export CWARNFLAGS ?= $(CWARNFLAGS_STD)
+@@ -170,6 +175,7 @@ CXXWARNFLAGS_STD = \
+ 	$(WARNFLAGS_STD) \
+ 	-Wno-c++98-compat-pedantic \
+ 	-Wno-exit-time-destructors \
++	-Wno-ignored-attributes \
+ 	-Wno-global-constructors \
+ 	-Wno-old-style-cast
+ 


### PR DESCRIPTION
This PR moves all the patches and build fixes from `SUFuji16E195.plist` into `Lobo17A365.plist`. I also took the opportunity to clean up a some of the messier patches while I was at it.