### PR TITLE
Add CoreOSMakefiles project

### DIFF
--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -147,6 +147,16 @@
 			<key>version</key>
 			<string>60118.1.1</string>
 		</dict>
+		<key>CoreOSMakefiles</key>
+		<dict>
+			<key>version</key>
+			<string>77</string>
+			<key>patchfiles</key>
+			<array>
+				<string>CoreOSMakefiles-77.no-xcrun.p1.patch</string>
+				<string>CoreOSMakefiles-77.install-location.p1.patch</string>
+			</array>
+		</dict>
 		<key>CrackLib</key>
 		<dict>
 			<key>version</key>

--- a/Lobo17A365.plist
+++ b/Lobo17A365.plist
@@ -155,6 +155,7 @@
 			<array>
 				<string>CoreOSMakefiles-77.no-xcrun.p1.patch</string>
 				<string>CoreOSMakefiles-77.install-location.p1.patch</string>
+				<string>CoreOSMakefiles-77.search-path.p1.patch</string>
 			</array>
 		</dict>
 		<key>CrackLib</key>

--- a/patches/CoreOSMakefiles-77.install-location.p1.patch
+++ b/patches/CoreOSMakefiles-77.install-location.p1.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 43d8377..10d4b3d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,6 @@
+ Project=CoreOSMakefiles
+ 
+-Destination = $(DEVELOPER_DIR)/Makefiles/CoreOS
++Destination ?= /usr/local/share/CoreOSMakefiles
+ BSDSUFFIX   = .mk
+ BSDDEFINE   = BSDMAKESTYLE
+ GNUSUFFIX   = .make

--- a/patches/CoreOSMakefiles-77.no-xcrun.p1.patch
+++ b/patches/CoreOSMakefiles-77.no-xcrun.p1.patch
@@ -1,0 +1,219 @@
+diff --git a/Standard/Commands.in b/Standard/Commands.in
+index bf88540..e2dd36f 100644
+--- a/Standard/Commands.in
++++ b/Standard/Commands.in
+@@ -46,181 +46,43 @@ TAR        = /usr/bin/tar
+ UNCOMPRESS = $(GUNZIP)
+ ZCAT       = $(GZCAT)
+ 
+-##
+-# How to find certain commands
+-##
+-PATH_OF_COMMAND = xcrun -find
+-
+ ##
+ # Compilers and Binary Tools
+ ##
+-#ifdef BSDMAKESTYLE
+-AR      != $(PATH_OF_COMMAND) ar
+-#else
+-AR      = $(shell $(PATH_OF_COMMAND) ar)
+-#endif
+-#ifdef BSDMAKESTYLE
+-AS      != $(PATH_OF_COMMAND) as
+-#else
+-AS      = $(shell $(PATH_OF_COMMAND) as)
+-#endif
+-#ifdef BSDMAKESTYLE
+-BISON   != $(PATH_OF_COMMAND) bison
+-#else
+-BISON   = $(shell $(PATH_OF_COMMAND) bison)
+-#endif
+-#ifdef BSDMAKESTYLE
+-BSDMAKE != $(PATH_OF_COMMAND) bsdmake
+-#else
+-BSDMAKE = $(shell $(PATH_OF_COMMAND) bsdmake)
+-#endif
+-#ifdef BSDMAKESTYLE
+-CC      != $(PATH_OF_COMMAND) cc
+-#else
+-CC      = $(shell $(PATH_OF_COMMAND) cc)
+-#endif
+-#ifdef BSDMAKESTYLE
+-C89     != $(PATH_OF_COMMAND) c89
+-#else
+-C89     = $(shell $(PATH_OF_COMMAND) c89)
+-#endif
+-#ifdef BSDMAKESTYLE
+-C99     != $(PATH_OF_COMMAND) c99
+-#else
+-C99     = $(shell $(PATH_OF_COMMAND) c99)
+-#endif
+-#ifdef BSDMAKESTYLE
+-CPP     != $(PATH_OF_COMMAND) cpp
+-#else
+-CPP     = $(shell $(PATH_OF_COMMAND) cpp)
+-#endif
+-#ifdef BSDMAKESTYLE
+-CTAGS   != $(PATH_OF_COMMAND) ctags
+-#else
+-CTAGS   = $(shell $(PATH_OF_COMMAND) ctags)
+-#endif
+-#ifdef BSDMAKESTYLE
+-Cxx     != $(PATH_OF_COMMAND) c++
+-#else
+-Cxx     = $(shell $(PATH_OF_COMMAND) c++)
+-#endif
++AR      = ar
++AS      = as
++BISON   = bison
++BSDMAKE = bsdmake
++CC      = cc
++C89     = c89
++C99     = c99
++CPP     = cpp
++CTAGS   = ctags
++Cxx     = c++
+ CXX     = $(Cxx)
+-#ifdef BSDMAKESTYLE
+-DSYMUTIL != $(PATH_OF_COMMAND) dsymutil
+-#else
+-DSYMUTIL = $(shell $(PATH_OF_COMMAND) dsymutil)
+-#endif
+-#ifdef BSDMAKESTYLE
+-DTRACE  != $(PATH_OF_COMMAND) dtrace
+-#else
+-DTRACE  = $(shell $(PATH_OF_COMMAND) dtrace)
+-#endif
+-#ifdef BSDMAKESTYLE
+-ETAGS   != $(PATH_OF_COMMAND) etags
+-#else
+-ETAGS   = $(shell $(PATH_OF_COMMAND) etags)
+-#endif
+-#ifdef BSDMAKESTYLE
+-FILE    != $(PATH_OF_COMMAND) file
+-#else
+-FILE    = $(shell $(PATH_OF_COMMAND) file)
+-#endif
+-#ifdef BSDMAKESTYLE
+-FLEX    != $(PATH_OF_COMMAND) flex
+-#else
+-FLEX    = $(shell $(PATH_OF_COMMAND) flex)
+-#endif
+-#ifdef BSDMAKESTYLE
+-GM4     != $(PATH_OF_COMMAND) gm4
+-#else
+-GM4     = $(shell $(PATH_OF_COMMAND) gm4)
+-#endif
+-#ifdef BSDMAKESTYLE
+-GNUMAKE != $(PATH_OF_COMMAND) gnumake
+-#else
+-GNUMAKE = $(shell $(PATH_OF_COMMAND) gnumake)
+-#endif
+-#ifdef BSDMAKESTYLE
+-LD      != $(PATH_OF_COMMAND) ld
+-#else
+-LD      = $(shell $(PATH_OF_COMMAND) ld)
+-#endif
+-LEX     = $(FLEX)
+-#ifdef BSDMAKESTYLE
+-LIBTOOL != $(PATH_OF_COMMAND) libtool
+-#else
+-LIBTOOL = $(shell $(PATH_OF_COMMAND) libtool)
+-#endif
+-#ifdef BSDMAKESTYLE
+-LIPO    != $(PATH_OF_COMMAND) lipo
+-#else
+-LIPO    = $(shell $(PATH_OF_COMMAND) lipo)
+-#endif
+-#ifdef BSDMAKESTYLE
+-LORDER  != $(PATH_OF_COMMAND) lorder
+-#else
+-LORDER  = $(shell $(PATH_OF_COMMAND) lorder)
+-#endif
+-#ifdef BSDMAKESTYLE
+-M4      != $(PATH_OF_COMMAND) m4
+-#else
+-M4      = $(shell $(PATH_OF_COMMAND) m4)
+-#endif
+-#ifdef BSDMAKESTYLE
+-MIG     != $(PATH_OF_COMMAND) mig
+-#else
+-MIG     = $(shell $(PATH_OF_COMMAND) mig)
+-#endif
+-#ifdef BSDMAKESTYLE
+-NM      != $(PATH_OF_COMMAND) nm
+-#else
+-NM      = $(shell $(PATH_OF_COMMAND) nm)
+-#endif
+-#ifdef BSDMAKESTYLE
+-OTOOL   != $(PATH_OF_COMMAND) otool
+-#else
+-OTOOL   = $(shell $(PATH_OF_COMMAND) otool)
+-#endif
+-#ifdef BSDMAKESTYLE
+-RANLIB  != $(PATH_OF_COMMAND) ranlib
+-#else
+-RANLIB  = $(shell $(PATH_OF_COMMAND) ranlib)
+-#endif
+-#ifdef BSDMAKESTYLE
+-RPCGEN  != $(PATH_OF_COMMAND) rpcgen
+-#else
+-RPCGEN  = $(shell $(PATH_OF_COMMAND) rpcgen)
+-#endif
+-#ifdef BSDMAKESTYLE
+-SIZE    != $(PATH_OF_COMMAND) size
+-#else
+-SIZE    = $(shell $(PATH_OF_COMMAND) size)
+-#endif
+-#ifdef BSDMAKESTYLE
+-STRINGS != $(PATH_OF_COMMAND) strings
+-#else
+-STRINGS = $(shell $(PATH_OF_COMMAND) strings)
+-#endif
+-#ifdef BSDMAKESTYLE
+-STRIP   != $(PATH_OF_COMMAND) strip
+-#else
+-STRIP   = $(shell $(PATH_OF_COMMAND) strip)
+-#endif
+-#ifdef BSDMAKESTYLE
+-TCONF   != $(PATH_OF_COMMAND) tconf
+-#else
+-TCONF   = $(shell $(PATH_OF_COMMAND) tconf)
+-#endif
+-#ifdef BSDMAKESTYLE
+-UNIFDEF != $(PATH_OF_COMMAND) unifdef
+-#else
+-UNIFDEF = $(shell $(PATH_OF_COMMAND) unifdef)
+-#endif
+-#ifdef BSDMAKESTYLE
+-YACC    != $(PATH_OF_COMMAND) yacc
+-#else
+-YACC    = $(shell $(PATH_OF_COMMAND) yacc)
+-#endif
++DSYMUTIL = dsymutil
++DTRACE  = dtrace
++ETAGS   = etags
++FILE    = file
++FLEX    = flex
++GM4     = gm4
++GNUMAKE = gnumake
++LD      = ld
++LIBTOOL = libtool
++LIPO    = lipo
++LORDER  = lorder
++M4      = m4
++MIG     = mig
++NM      = nm
++OTOOL   = otool
++RANLIB  = ranlib
++RPCGEN  = rpcgen
++SIZE    = size
++STRINGS = strings
++STRIP   = strip
++TCONF   = tconf
++UNIFDEF = unifdef
++YACC    = yacc
+ 
+ ##
+ # File Commands

--- a/patches/CoreOSMakefiles-77.search-path.p1.patch
+++ b/patches/CoreOSMakefiles-77.search-path.p1.patch
@@ -1,0 +1,13 @@
+diff --git a/ReleaseControl/Common.make b/ReleaseControl/Common.make
+index b874c42..3c50eb7 100644
+--- a/ReleaseControl/Common.make
++++ b/ReleaseControl/Common.make
+@@ -36,7 +36,7 @@
+ ##
+ 
+ ifndef CoreOSMakefiles
+-CoreOSMakefiles = $(MAKEFILEPATH)/CoreOS
++CoreOSMakefiles = $(RC_BuildRoot)/usr/local/share/CoreOSMakefiles
+ endif
+ 
+ include $(CoreOSMakefiles)/Standard/Standard.make


### PR DESCRIPTION
The copy of these makefiles that ships with Xcode no longer functions, because it defines the path to the compiler and other tools in an incompatible way. (I filed a radar about this, and they closed it as by-design.)